### PR TITLE
Add the packaging metadata to build the mapscii snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: mapscii
+version: master
+summary: The Whole World In Your Console
+description: |
+  A node.js based Vector Tile to Braille and ASCII renderer for
+  xterm-compatible terminals.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  mapscii:
+    command: mapscii
+    plugs: [network]
+
+parts:
+  mapscii:
+    source: .
+    plugin: nodejs


### PR DESCRIPTION
This package will let you publish the latest mapscii in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.