### PR TITLE
Bug fix: utils.hex2rgb does not fail on invalid hex strings

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -59,7 +59,7 @@ const utils = {
   hex2rgb: (color) => {
     if (typeof color !== 'string') return [255, 0, 0];
 
-    if (/^#[a-fA-F0-9]{3,6}$/.test()) {
+    if (/^#[a-fA-F0-9]{3,6}$/.test(color)) {
       throw new Error('#{color} isn\'t a supported hex color');
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -59,8 +59,8 @@ const utils = {
   hex2rgb: (color) => {
     if (typeof color !== 'string') return [255, 0, 0];
 
-    if (/^#[a-fA-F0-9]{3,6}$/.test(color)) {
-      throw new Error('#{color} isn\'t a supported hex color');
+    if (!/^#[a-fA-F0-9]{3,6}$/.test(color)) {
+      throw new Error(`${color} isn't a supported hex color`);
     }
 
     color = color.substr(1);

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -1,0 +1,28 @@
+'use strict';
+const utils = require('./utils');
+
+describe('utils', () => {
+  describe('hex2rgb', () => {
+    test('#ff0000', () => {
+      expect(utils.hex2rgb('#ff0000')).toEqual([255,0,0]);
+    });
+    test('#ffff00', () => {
+      expect(utils.hex2rgb('#ffff00')).toEqual([255,255,0]);
+    });
+    test('#0000ff', () => {
+      expect(utils.hex2rgb('#0000ff')).toEqual([0,0,255]);
+    });
+    test('#112233', () => {
+      expect(utils.hex2rgb('#112233')).toEqual([17,34,51]);
+    });
+    test('#888', () => {
+      expect(utils.hex2rgb('#888')).toEqual([136,136,136]);
+    });
+    test('33', () => {
+      function wrapper() {
+        utils.hex2rgb('33');
+      }
+      expect(wrapper).toThrowError('isn\'t a supported hex color');
+    });
+  });
+});


### PR DESCRIPTION
`utils.hex2rgb` accepts hex strings, however, the if condition is broken.

This PR also adds some basic unit tests for the function.