### PR TITLE
Add GitHub issue templates to the repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/BugReport.md
+++ b/.github/ISSUE_TEMPLATE/BugReport.md
@@ -1,0 +1,26 @@
+---
+name: "\U0001F41B Bug report"
+about: Something isn’t working as expected
+---
+
+**Steps to reproduce**
+
+<!--
+A step by step description of how to get to the error state.
+Are you using the the telnet or the local client?
+If you run Mapscii locally, what is your NodeJS version? (run `node -v`)
+It might help to know which operating system and keyboard language your are using.
+-->
+
+**Current behavior**
+
+<!--
+A clear and concise description of what the bug is.
+Please include any JavaScript errors
+-->
+
+**Expected behavior**
+
+<!--
+What did you expect to happen?
+-->

--- a/.github/ISSUE_TEMPLATE/BugReport.md
+++ b/.github/ISSUE_TEMPLATE/BugReport.md
@@ -8,7 +8,7 @@ about: Something isn’t working as expected
 <!--
 A step by step description of how to get to the error state.
 Are you using the the telnet or the local client?
-If you run Mapscii locally, what is your NodeJS version? (run `node -v`)
+If you run MapSCII locally, what is your NodeJS version? (run `node -v`)
 It might help to know which operating system and keyboard language your are using.
 -->
 

--- a/.github/ISSUE_TEMPLATE/FeatureRequest.md
+++ b/.github/ISSUE_TEMPLATE/FeatureRequest.md
@@ -1,0 +1,22 @@
+---
+name: "\U0001F680 Feature request"
+about: I have a suggestion (and might want to implement myself)
+---
+
+<!-- Consider opening a pull request instead: it’s a more productive way to discuss new features -->
+
+**The problem**
+
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Proposed solution**
+
+<!-- A clear and concise description of what you want to happen. Add any considered drawbacks. -->
+
+**Alternative solutions**
+
+<!-- A clear and concise description of any alternative solutions or features you’ve considered. -->
+
+**Additional context**
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,0 +1,14 @@
+---
+name: "\U0001F914 Support question"
+about: I have a question or don’t know how to do something
+---
+
+--------------^ Click “Preview”!
+
+If you have a support question, feel free to ask it here.
+
+Before submitting a new question, make sure you:
+
+- Searched opened and closed [GitHub issues](https://github.com/rastapasta/mapscii/issues?utf8=%E2%9C%93&q=is%3Aissue).
+- Read [the introduction](https://github.com/rastapasta/mapscii/blob/master/README.md).
+- Read [the wiki article](hhttps://wiki.openstreetmap.org/wiki/Mapscii).

--- a/.github/ISSUE_TEMPLATE/Support.md
+++ b/.github/ISSUE_TEMPLATE/Support.md
@@ -1,15 +1,15 @@
 ---
-name: "\U0001F984 Support Mapscii’s development"
+name: "\U0001F984 Support MapSCII’s development"
 about: I want to support efforts in maintaining this community-driven project
 ---
 
 --------------^ Click “Preview”!
 
-Developing and maintaining an open source project is a big effort. Mapscii isn’t supported by any big company, and all the contributors are working on it in their free time. We need your help to make it sustainable.
+Developing and maintaining an open source project is a big effort. MapSCII isn’t supported by any big company, and all the contributors are working on it in their free time. We need your help to make it sustainable.
 
 There are many ways you can help:
 
 - Answer questions in [GitHub issues](https://github.com/rastapasta/mapscii/issues).
 - Review [pull requests](https://github.com/rastapasta/mapscii/pulls).
 - Fix bugs and add new features.
-- Write articles and talk about Mapscii on conferences and meetups (we’re always happy to review your texts and slides).
+- Write articles and talk about MapSCII on conferences and meetups (we’re always happy to review your texts and slides).

--- a/.github/ISSUE_TEMPLATE/Support.md
+++ b/.github/ISSUE_TEMPLATE/Support.md
@@ -1,0 +1,15 @@
+---
+name: "\U0001F984 Support Mapscii’s development"
+about: I want to support efforts in maintaining this community-driven project
+---
+
+--------------^ Click “Preview”!
+
+Developing and maintaining an open source project is a big effort. Mapscii isn’t supported by any big company, and all the contributors are working on it in their free time. We need your help to make it sustainable.
+
+There are many ways you can help:
+
+- Answer questions in [GitHub issues](https://github.com/rastapasta/mapscii/issues).
+- Review [pull requests](https://github.com/rastapasta/mapscii/pulls).
+- Fix bugs and add new features.
+- Write articles and talk about Mapscii on conferences and meetups (we’re always happy to review your texts and slides).

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 /*#
-  mapscii - Terminal Map Viewer
+  MapSCII - Terminal Map Viewer
   by Michael Strassburger <codepoet@cpan.org>
   Discover the planet in your console!
 

--- a/src/Mapscii.js
+++ b/src/Mapscii.js
@@ -1,5 +1,5 @@
 /*
-  mapscii - Terminal Map Viewer
+  MapSCII - Terminal Map Viewer
   by Michael Strassburger <codepoet@cpan.org>
 
   UI and central command center

--- a/src/TileSource.js
+++ b/src/TileSource.js
@@ -15,7 +15,7 @@ const Tile = require('./Tile');
 const config = require('./config');
 
 // https://github.com/mapbox/node-mbtiles has native build dependencies (sqlite3)
-// To maximize mapscii's compatibility, MBTiles support must be manually added via
+// To maximize MapSCII’s compatibility, MBTiles support must be manually added via
 // $> npm install -g mbtiles
 let MBTiles = null;
 try {


### PR DESCRIPTION
I saw these awesome GitHub issue templates by @sapegin on https://github.com/styleguidist/react-styleguidist/. 👌
They got adapted to what I think the current processes should/could be.