### PR TITLE
Throw an error if creating a folder fails.

### DIFF
--- a/src/TileSource.js
+++ b/src/TileSource.js
@@ -169,6 +169,7 @@ class TileSource {
       return true;
     } catch (error) {
       return error.code === 'EEXIST';
+      throw error;
     }
   }
 }

--- a/src/TileSource.js
+++ b/src/TileSource.js
@@ -168,7 +168,7 @@ class TileSource {
       fs.mkdirSync(path);
       return true;
     } catch (error) {
-      return error.code === 'EEXIST';
+      if (error.code === 'EEXIST') return true;
       throw error;
     }
   }


### PR DESCRIPTION
The catch block should throw the error if, it was not able to create the folder.
Currently MapSCII seems to ignore these errors.

This might lead to Mapscii.js having to handle with the error during the initialization.