### PR TITLE
Unhandled mapscii init

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,4 +11,7 @@
 const Mapscii = require('./src/Mapscii');
 
 const mapscii = new Mapscii();
-mapscii.init();
+mapscii.init().catch((err) => {
+  console.error('Failed to start MapSCII.');
+  console.error(err);
+});

--- a/src/Mapscii.js
+++ b/src/Mapscii.js
@@ -43,18 +43,15 @@ class Mapscii {
     config = Object.assign(config, options);
   }
 
-  init() {
-    return new Promise((resolve) => {
-      if (!config.headless) {
-        this._initKeyboard();
-        this._initMouse();
-      }
-      this._initTileSource();
-      this._initRenderer();
-      this._draw();
-      this.notify('Welcome to MapSCII! Use your cursors to navigate, a/z to zoom, q to quit.');
-      resolve();
-    });
+  async init() {
+    if (!config.headless) {
+      this._initKeyboard();
+      this._initMouse();
+    }
+    this._initTileSource();
+    this._initRenderer();
+    this._draw();
+    this.notify('Welcome to MapSCII! Use your cursors to navigate, a/z to zoom, q to quit.');
   }
 
 


### PR DESCRIPTION
`Mapscii.init()` returns a Promise. All Promises have to be handled.

In this case it should be safe to just print the error. I did not add `process.exit(1);` because the executing of console commands can be async and interrupted by a process being force quit.