### PR TITLE
The NPM package mbtiles got deprecated in favour of @mapbox/mbtiles

### DIFF
--- a/src/TileSource.js
+++ b/src/TileSource.js
@@ -16,10 +16,10 @@ const config = require('./config');
 
 // https://github.com/mapbox/node-mbtiles has native build dependencies (sqlite3)
 // To maximize MapSCII’s compatibility, MBTiles support must be manually added via
-// $> npm install -g mbtiles
+// $> npm install -g @mapbox/mbtiles
 let MBTiles = null;
 try {
-  MBTiles = require('mbtiles');
+  MBTiles = require('@mapbox/mbtiles');
 } catch (err) {void 0;}
 
 const modes = {
@@ -49,7 +49,7 @@ class TileSource {
 
     } else if (this.source.endsWith('.mbtiles')) {
       if (!MBTiles) {
-        throw new Error('MBTiles support must be installed with following command: \'npm install -g mbtiles\'');
+        throw new Error('MBTiles support must be installed with following command: \'npm install -g @mapbox/mbtiles\'');
       }
 
       this.mode = modes.MBTiles;

--- a/src/TileSource.spec.js
+++ b/src/TileSource.spec.js
@@ -2,10 +2,10 @@
 const TileSource = require('./TileSource');
 
 describe('TileSource', () => {
-  describe('with a HTTP source', async () => {
-    const tileSource = new TileSource();
-    await tileSource.init('http://mapscii.me/');
-    test('sets the mode to 3', () => {
+  describe('with a HTTP source', () => {
+    test('sets the mode to 3', async () => {
+      const tileSource = new TileSource();
+      await tileSource.init('http://mapscii.me/');
       tileSource.mode = 3;
     });
   });

--- a/src/TileSource.spec.js
+++ b/src/TileSource.spec.js
@@ -1,0 +1,12 @@
+'use strict';
+const TileSource = require('./TileSource');
+
+describe('TileSource', () => {
+  describe('with a HTTP source', async () => {
+    const tileSource = new TileSource();
+    await tileSource.init('http://mapscii.me/');
+    test('sets the mode to 3', () => {
+      tileSource.mode = 3;
+    });
+  });
+});


### PR DESCRIPTION
This changes the install recommendation and the import from `mbtiles` to `@mapbox/mbtiles`.

When installing `mbtiles` one is presented the following warnings:
```
$ npm install mbtiles
npm WARN deprecated mbtiles@0.9.0: This module has moved: please install @mapbox/mbtiles instead
npm WARN deprecated tiletype@0.1.0: This module is now under the @mapbox namespace: install @mapbox/tiletype instead
npm WARN deprecated sphericalmercator@1.0.5: This module is now under the @mapbox namespace: install @mapbox/sphericalmercator instead
```