### PR TITLE
Fix issue where every button press causes a rerender

### DIFF
--- a/src/Mapscii.js
+++ b/src/Mapscii.js
@@ -225,7 +225,7 @@ class Mapscii {
         draw = false;
     }
 
-    if (draw !== null) {
+    if (draw) {
       this._draw();
     }
   }


### PR DESCRIPTION
Because of a faulty condition, the map is redrawn on every button press.
This PR fixes the condition which checks for `draw !== null` where draw is a boolean and never `null`.