### PR TITLE
Start a dedicated AUTHORS file for copyright purposes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,6 @@
+# This is the list of MapSCII authors for copyright purposes.
+#
+Michael Straßburger
+Christian Paul (https://chrpaul.de)
+Jannis R <mail@jannisr.de>
+Alexander Zhukov (https://github.com/ZhukovAlexander)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2016 Michael Straßburger
+Copyright (c) 2017 Michael Straßburger
+Copyright (c) 2019 The MapSCII authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -132,13 +132,5 @@ You are free to copy, distribute, transmit and adapt our data, as long as you cr
 The cartography in our map tiles, and our documentation, are licenced under the [Creative Commons Attribution-ShareAlike 2.0](http://creativecommons.org/licenses/by-sa/2.0/) licence (CC BY-SA).
 
 ### MapSCII
-
-#### The MIT License (MIT)
-
-Copyright (c) 2017 Michael Straßburger
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+* [License](./LICENSE)
+* [Authors](./AUTHORS)


### PR DESCRIPTION
To resolve part of #20, I want to add an `AUTHORS` file for copyright purposes.
I also want to move the License out of `README.md` and only mention it as an MIT License to avoid maintaining two sources of truth. They already differed.
I would be fine with a script that append the License to the end of `README.md`.