### PR TITLE
Remove support for Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "mapscii": "./bin/mapscii.sh"
   },
   "engines": {
-    "node": ">=6.14.0"
+    "node": ">=8"
   },
   "keywords": [
     "map",


### PR DESCRIPTION
Node 6 does not support `async` and libraries start dropping support for it. [The LTS support for Node 6 will end this month.](https://nodejs.org/en/about/releases/)
Because there is not a lot happening in this project and the support for various versions takes time I will remove Node 6 and am in favour of moving to only support the latest LTS.