### PR TITLE
Add vim keys as alternative to arrow key navigation

### DIFF
--- a/src/Mapscii.js
+++ b/src/Mapscii.js
@@ -208,15 +208,19 @@ class Mapscii {
         this.zoomBy(-config.zoomStep);
         break;
       case 'left':
+      case 'h':
         this.moveBy(0, -8/Math.pow(2, this.zoom));
         break;
       case 'right':
+      case 'l':
         this.moveBy(0, 8/Math.pow(2, this.zoom));
         break;
       case 'up':
+      case 'k':
         this.moveBy(6/Math.pow(2, this.zoom), 0);
         break;
       case 'down':
+      case 'j':
         this.moveBy(-6/Math.pow(2, this.zoom), 0);
         break;
       case 'c':


### PR DESCRIPTION
This functionality seems obligatory with most terminal applications, so I thought I'd add it real quick.  Since it does not appear that there are any options yet available for customizing key bindings, I hard-coded these keys just like all the other keys.