### PR TITLE
Raise the minimum NodeJS version to 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"
+  - "14"
 
 script:
   - npm run-script lint

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npx mapscii
 
 ### With npm
 
-If you haven't already got Node.js >= version 6.14, then [go get it](http://nodejs.org/).
+If you haven't already got Node.js >= version 10, then [go get it](http://nodejs.org/).
 
 ```
 npm install -g mapscii

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "mapscii": "./bin/mapscii.sh"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "keywords": [
     "map",


### PR DESCRIPTION
NodeJS version 8 is no longer supported by its developers. The latest Long Term Support (LTS) version is now NodeJS 10.
An upgrade to our development dependency Jest made our CI fail. This raise fixes our CI (without actually changing the code – so Mapscii may still work with NodeJS 8).

The commit that broke the CI: https://github.com/rastapasta/mapscii/commit/8475501605b80e68114cdeb57ab36963606237fe