### PR TITLE
Remove bluebird

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ If your terminal supports mouse events you can drag the map and use your scroll 
 * [`simplify-js`](https://github.com/mourner/simplify-js) for polyline simplifications
 
 #### Handling the flow
-* [`bluebird`](https://github.com/petkaantonov/bluebird) for all the asynchronous [Promise](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Promise) magic
 * [`node-fetch`](https://github.com/bitinn/node-fetch) for HTTP requests
 * [`env-paths`](https://github.com/sindresorhus/env-paths) to determine where to persist downloaded tiles
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1107,11 +1107,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "license": "MIT",
   "dependencies": {
     "@mapbox/vector-tile": "^1.3.1",
-    "bluebird": "^3.7.2",
     "bresenham": "0.0.4",
     "earcut": "^2.2.2",
     "env-paths": "^2.2.0",


### PR DESCRIPTION
Removes the `bluebird` dependency in favour of JavaScript's Promise.

Also includes:
- `renderer.draw()` no longer throws when the tileSource returned no tiles for an area (e.g. no zoom set)
  - https://github.com/rastapasta/mapscii/pull/94/files#diff-22bbd585b90d89f7144d6211224fa19fR137
- `renderer.draw()` prints errors to `stderr` instead of `stdout`.
  - https://github.com/rastapasta/mapscii/pull/94/files#diff-22bbd585b90d89f7144d6211224fa19fR60